### PR TITLE
Add option to override default cURL user-agent

### DIFF
--- a/config/feed-reader.php
+++ b/config/feed-reader.php
@@ -66,6 +66,13 @@ return [
              * @var boolean
              */
             'ssl-verify' => true,
+
+            /**
+             * The cURL user-agent to use for the request (if left blank, defaults to 'curl/[version]')
+             *
+             * @var string
+             */
+            'curl-useragent' => ''
         ],
     ],
 ];

--- a/src/FeedReader.php
+++ b/src/FeedReader.php
@@ -55,11 +55,24 @@ class FeedReader
         // Should we be ordering the feed by date?
         $sp->enable_order_by_date($this->readConfig($configuration, 'order-by-date', false));
 
+        $curlOptions = [];
+
+        // Should we verify SSL
         if (! $this->readConfig($configuration, 'ssl-verify', true)) {
-            $sp->set_curl_options([
+            $curlOptions = [
                 CURLOPT_SSL_VERIFYHOST => false,
                 CURLOPT_SSL_VERIFYPEER => false,
-            ]);
+            ];
+        }
+
+        // Should we override the default cURL user-agent?
+        if (! empty($this->readConfig($configuration, 'curl-useragent', false))) {
+            $curlOptions[CURLOPT_USERAGENT] = $this->readConfig($configuration, 'curl-useragent', false);
+        }
+
+        // Set cURL options
+        if (! empty($curlOptions)) {
+            $sp->set_curl_options($curlOptions);
         }
 
         // Set the feed URL


### PR DESCRIPTION
Some web servers will block requests coming from the default cURL user-agent (which is usually something like "curl/< version >").

This change makes it possible to add a new config option to override the cURL user-agent e.g.

```
/**
 * The cURL user-agent to use for the request.
 *
 * @var string
 */
'curl-useragent' => 'Mozilla/5.0 (Windows NT 6.2; WOW64; rv:17.0) Gecko/20100101 Firefox/17.0'
```

Doing so will enable your client to pose as a different user-agent, preventing its requests from being blocked.