### PR TITLE
Allow for passing curl options

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,20 @@ This function accepts 2 parameters however, the second parameter is optional.  T
 This will return to you the SimplePie object with the RSS feed in it.
 See [SimplePie](http://simplepie.org/api/index.html) API for all available methods.
 
+#### Passing curl options
+You can also pass specific curl options per `read()` calls. You can pass these options, as an `array` as the 3rd parameter. The list of options can be found on the [PHP Manual](https://www.php.net/manual/en/function.curl-setopt.php).
+
+Example:
+```php
+// You need to log in to the rss endpoint with a Digest auth
+$options = [
+    CURLOPT_HTTPAUTH => CURLAUTH_DIGEST,
+    CURLOPT_USERPWD => 'username:password'
+];
+
+$f = FeedReader::read('https://news.google.com/news/rss', null, $options);
+```
+
 ## License
 
 Feed Reader is free software distributed under the terms of the MIT license

--- a/README.md
+++ b/README.md
@@ -85,11 +85,12 @@ Example:
 ```php
 // You need to log in to the rss endpoint with a Digest auth
 $options = [
+    'curl_options' => [
     CURLOPT_HTTPAUTH => CURLAUTH_DIGEST,
     CURLOPT_USERPWD => 'username:password'
-];
+]];
 
-$f = FeedReader::read('https://news.google.com/news/rss', null, $options);
+$f = FeedReader::read('https://news.google.com/news/rss', 'default', $options);
 ```
 
 ## License

--- a/src/FeedReader.php
+++ b/src/FeedReader.php
@@ -28,9 +28,10 @@ class FeedReader
      *
      * @param        $url
      * @param string $configuration
+     * @param array  $curlOptions - refer to https://www.php.net/manual/en/function.curl-setopt.php for full list
      * @return SimplePie
      */
-    public function read($url, $configuration = 'default')
+    public function read($url, $configuration = 'default', array $curlOptions)
     {
         // Setup the object
         $sp = $this->app->make(SimplePie::class);
@@ -60,6 +61,11 @@ class FeedReader
                 CURLOPT_SSL_VERIFYHOST => false,
                 CURLOPT_SSL_VERIFYPEER => false,
             ]);
+        }
+
+        // If the user passes manual curl options, let's add them
+        if (count($curlOptions) > 0) {
+            $sp->set_curl_options($curlOptions);
         }
 
         // Set the feed URL

--- a/src/FeedReader.php
+++ b/src/FeedReader.php
@@ -64,7 +64,7 @@ class FeedReader
         }
 
         // If the user passes manual curl options, let's add them
-        if (count($options['curl_options']) > 0) {
+        if (isset($options['curl_options'])) {
             $sp->set_curl_options($options['curl_options']);
         }
 

--- a/src/FeedReader.php
+++ b/src/FeedReader.php
@@ -31,7 +31,7 @@ class FeedReader
      * @param array  $curlOptions - refer to https://www.php.net/manual/en/function.curl-setopt.php for full list
      * @return SimplePie
      */
-    public function read($url, $configuration = 'default', array $curlOptions)
+    public function read($url, $configuration = 'default', array $curlOptions = [])
     {
         // Setup the object
         $sp = $this->app->make(SimplePie::class);

--- a/src/FeedReader.php
+++ b/src/FeedReader.php
@@ -28,10 +28,10 @@ class FeedReader
      *
      * @param        $url
      * @param string $configuration
-     * @param array  $curlOptions - refer to https://www.php.net/manual/en/function.curl-setopt.php for full list
+     * @param array  $options
      * @return SimplePie
      */
-    public function read($url, $configuration = 'default', array $curlOptions = [])
+    public function read($url, $configuration = 'default', array $options = [])
     {
         // Setup the object
         $sp = $this->app->make(SimplePie::class);
@@ -64,8 +64,8 @@ class FeedReader
         }
 
         // If the user passes manual curl options, let's add them
-        if (count($curlOptions) > 0) {
-            $sp->set_curl_options($curlOptions);
+        if (count($options['curl_options']) > 0) {
+            $sp->set_curl_options($options['curl_options']);
         }
 
         // Set the feed URL

--- a/tests/Unit/FeedReaderTest.php
+++ b/tests/Unit/FeedReaderTest.php
@@ -30,6 +30,28 @@ class FeedReaderTest extends TestCase
         $this->assertEquals('FeedForAll Sample Feed', $rss->get_title());
         $this->assertObjectHasAttribute('term', $rss->get_category());
         $this->assertEquals(9, $rss->get_item_quantity());
+        // No curl options passed
+        $this->assertEquals([], $rss->curl_options);
+
+        self::$process->stop();
+    }
+
+    public function testReadRssWithOptions()
+    {
+        self::$process = new Process(['php', '-S', 'localhost:8123', '-t', './tests/resources']);
+        self::$process->start();
+        usleep(500000);
+
+        /** @var SimplePie $rss */
+        $rss = FeedReaderFacade::read('http://localhost:8123/rss.xml', null, [
+            CURLOPT_HTTPAUTH => CURLAUTH_DIGEST,
+            CURLOPT_USERPWD => 'username:password'
+        ]);
+
+        $this->assertEquals([
+            107 => 2,
+            10005 => "username:password"
+        ], $rss->curl_options);
 
         self::$process->stop();
     }

--- a/tests/Unit/FeedReaderTest.php
+++ b/tests/Unit/FeedReaderTest.php
@@ -43,10 +43,10 @@ class FeedReaderTest extends TestCase
         usleep(500000);
 
         /** @var SimplePie $rss */
-        $rss = FeedReaderFacade::read('http://localhost:8123/rss.xml', null, [
+        $rss = FeedReaderFacade::read('http://localhost:8123/rss.xml', null, ['curl_options' => [
             CURLOPT_HTTPAUTH => CURLAUTH_DIGEST,
             CURLOPT_USERPWD => 'username:password'
-        ]);
+        ]]);
 
         $this->assertEquals([
             107 => 2,


### PR DESCRIPTION
This PR aims to allow the user to pass along to the `read` method some curl options.

**Scenario**
If you want to read a feed from a platform/website that requires authentication, you can't at the moment.
By passing curl options manually to the `read` method, the user can add any tools that they would require per call.
